### PR TITLE
chore: bump go-wallet-sdk and adapt to changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,17 @@
     "go-wallet-sdk": {
       "flake": false,
       "locked": {
-        "lastModified": 1757507797,
-        "narHash": "sha256-I67D+GypL7LuNuiXqk6TZjc4tTLb4NGRW40C51D+Yhc=",
+        "lastModified": 1764275000,
+        "narHash": "sha256-4JXzlUbx3VEXEwu8kSLdsl85/dyJQ7AzHvmFPPpAW1E=",
         "owner": "status-im",
         "repo": "go-wallet-sdk",
-        "rev": "de483fec457ebec76d4f6ad09f1104f0839ce47d",
+        "rev": "1739c1592948f4ba34026b73b9b1b54655d07c32",
         "type": "github"
       },
       "original": {
         "owner": "status-im",
         "repo": "go-wallet-sdk",
-        "rev": "de483fec457ebec76d4f6ad09f1104f0839ce47d",
+        "rev": "1739c1592948f4ba34026b73b9b1b54655d07c32",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-liblogos.url = "github:logos-co/logos-liblogos";
     go-wallet-sdk = {
-      url = "github:status-im/go-wallet-sdk/de483fec457ebec76d4f6ad09f1104f0839ce47d";
+      url = "github:status-im/go-wallet-sdk/1739c1592948f4ba34026b73b9b1b54655d07c32";
       flake = false;
     };
   };

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -35,7 +35,7 @@ pkgs.stdenv.mkDerivation {
     
     cd vendor/go-wallet-sdk
     echo "Go version: $(go version)"
-    make build-c-lib
+    make shared-library
     cd ../..
     
     mkdir -p lib

--- a/wallet_module_plugin.cpp
+++ b/wallet_module_plugin.cpp
@@ -15,7 +15,7 @@ WalletModulePlugin::~WalletModulePlugin()
         logosAPI = nullptr;
     }
     if (walletHandle != 0) {
-        GoWSK_CloseClient(walletHandle);
+        GoWSK_ethclient_CloseClient(walletHandle);
         walletHandle = 0;
     }
 }
@@ -44,7 +44,7 @@ bool WalletModulePlugin::initWallet(const QString &configJson)
 
     const char* url = "https://ethereum-rpc.publicnode.com";
     char* err = nullptr;
-    walletHandle = GoWSK_NewClient((char*)url, &err);
+    walletHandle = GoWSK_ethclient_NewClient((char*)url, &err);
     if (walletHandle == 0) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);
@@ -65,7 +65,7 @@ QString WalletModulePlugin::chainId(const QString &rpcUrl)
         }
     }
     char* err = nullptr;
-    char* chain = GoWSK_ChainID(walletHandle, &err);
+    char* chain = GoWSK_ethclient_ChainID(walletHandle, &err);
     if (chain == nullptr) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);
@@ -88,7 +88,7 @@ QString WalletModulePlugin::getEthBalance(const QString &rpcUrl, const QString &
     }
     QByteArray addrUtf8 = address.toUtf8();
     char* err = nullptr;
-    char* balance = GoWSK_GetBalance(walletHandle, addrUtf8.data(), &err);
+    char* balance = GoWSK_ethclient_GetBalance(walletHandle, addrUtf8.data(), &err);
     if (balance == nullptr) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);


### PR DESCRIPTION
Several changes were introduced to go-wallet-sdk based on PR suggestions (https://github.com/status-im/go-wallet-sdk/pull/13/commits/c0d5d0bc864631cac18df0c6b6c98c2a71d0f9fd). The ones relevant for integration in `logos-wallet-module` are:
- makefile target name for shared library set to `shared-library`
- c function names now have a "namespace" in the second position (`ethclient` for the initial available ones).

This PR switches to the latest go-wallet-sdk master HEAD (https://github.com/status-im/go-wallet-sdk/pull/13/commits/c0d5d0bc864631cac18df0c6b6c98c2a71d0f9fd) and takes care of these changes.

`nix build` was run and the plugin built successfully.