### PR TITLE
feat: implement transaction and txgenerator

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,17 @@
     "go-wallet-sdk": {
       "flake": false,
       "locked": {
-        "lastModified": 1765217560,
-        "narHash": "sha256-O2dVHZkIb+Z74ecMId5fB1eLmYNnIn4KbtZWkerDHN0=",
+        "lastModified": 1767895376,
+        "narHash": "sha256-XUWdi2m9bOhHlwk8KTr/mVkwtRxutiQVX7en0QxbVJw=",
         "owner": "status-im",
         "repo": "go-wallet-sdk",
-        "rev": "ddd7d9d523ba44a34f1e57f2f0535a0157a1dd92",
+        "rev": "f6c0924394c5bdf361bd16b739a80432e68291f5",
         "type": "github"
       },
       "original": {
         "owner": "status-im",
         "repo": "go-wallet-sdk",
-        "rev": "ddd7d9d523ba44a34f1e57f2f0535a0157a1dd92",
+        "rev": "f6c0924394c5bdf361bd16b739a80432e68291f5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     logos-cpp-sdk.url = "github:logos-co/logos-cpp-sdk";
     logos-liblogos.url = "github:logos-co/logos-liblogos";
     go-wallet-sdk = {
-      url = "github:status-im/go-wallet-sdk/ddd7d9d523ba44a34f1e57f2f0535a0157a1dd92";
+      url = "github:status-im/go-wallet-sdk/f6c0924394c5bdf361bd16b739a80432e68291f5";
       flake = false;
     };
   };

--- a/wallet_module_interface.h
+++ b/wallet_module_interface.h
@@ -9,11 +9,12 @@ public:
     virtual ~WalletModuleInterface() {}
 
     // EthClient operations
-    Q_INVOKABLE virtual bool initWallet(const QString &configJson) = 0;
-    Q_INVOKABLE virtual QString rpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON) = 0;
-    Q_INVOKABLE virtual QString chainId(const QString &rpcUrl) = 0;
-    Q_INVOKABLE virtual QString getEthBalance(const QString &rpcUrl, const QString &address) = 0;
-    Q_INVOKABLE virtual QString getErc20Balances(const QString &rpcUrl, const QString &address, const QStringList &tokenAddresses) = 0;
+    Q_INVOKABLE virtual bool ethClientInit(const QString &rpcUrl) = 0;
+    Q_INVOKABLE virtual bool ethClientClose(const QString &rpcUrl) = 0;
+    Q_INVOKABLE virtual QStringList ethClientGetClients() = 0;
+    Q_INVOKABLE virtual QString ethClientRpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString ethClientChainId(const QString &rpcUrl) = 0;
+    Q_INVOKABLE virtual QString ethClientGetBalance(const QString &rpcUrl, const QString &address) = 0;
 
     // TxGenerator operations
     Q_INVOKABLE virtual QString txGeneratorTransferETH(const QString &paramsJSON) = 0;

--- a/wallet_module_interface.h
+++ b/wallet_module_interface.h
@@ -8,12 +8,29 @@ class WalletModuleInterface : public PluginInterface
 public:
     virtual ~WalletModuleInterface() {}
 
-    // Example operations; will be expanded as we integrate SDK
+    // EthClient operations
     Q_INVOKABLE virtual bool initWallet(const QString &configJson) = 0;
     Q_INVOKABLE virtual QString rpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON) = 0;
     Q_INVOKABLE virtual QString chainId(const QString &rpcUrl) = 0;
     Q_INVOKABLE virtual QString getEthBalance(const QString &rpcUrl, const QString &address) = 0;
     Q_INVOKABLE virtual QString getErc20Balances(const QString &rpcUrl, const QString &address, const QStringList &tokenAddresses) = 0;
+
+    // TxGenerator operations
+    Q_INVOKABLE virtual QString txGeneratorTransferETH(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorTransferERC20(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorApproveERC20(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorTransferFromERC721(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorSafeTransferFromERC721(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorApproveERC721(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorSetApprovalForAllERC721(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorTransferERC1155(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorBatchTransferERC1155(const QString &paramsJSON) = 0;
+    Q_INVOKABLE virtual QString txGeneratorSetApprovalForAllERC1155(const QString &paramsJSON) = 0;
+
+    // Transaction operations
+    Q_INVOKABLE virtual QString transactionJsonToRlp(const QString &txJSON) = 0;
+    Q_INVOKABLE virtual QString transactionRlpToJson(const QString &rlpHex) = 0;
+    Q_INVOKABLE virtual QString transactionGetHash(const QString &txJSON) = 0;
 
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);

--- a/wallet_module_plugin.cpp
+++ b/wallet_module_plugin.cpp
@@ -3,7 +3,7 @@
 #include <QVariantList>
 #include <QDateTime>
 
-WalletModulePlugin::WalletModulePlugin() : walletHandle(0)
+WalletModulePlugin::WalletModulePlugin()
 {
     qDebug() << "WalletModulePlugin: Initializing...";
 }
@@ -14,10 +14,10 @@ WalletModulePlugin::~WalletModulePlugin()
         delete logosAPI;
         logosAPI = nullptr;
     }
-    if (walletHandle != 0) {
-        GoWSK_ethclient_CloseClient(walletHandle);
-        walletHandle = 0;
+    foreach (unsigned long long handle, ethClientHandles.values()) {
+        GoWSK_ethclient_CloseClient(handle);
     }
+    ethClientHandles.clear();
 }
 
 void WalletModulePlugin::initLogos(LogosAPI* logosAPIInstance) {
@@ -37,35 +37,66 @@ void WalletModulePlugin::simple_callback(int callerRet, const char* msg, size_t 
     }
 }
 
-bool WalletModulePlugin::initWallet(const QString &configJson)
+bool WalletModulePlugin::ethClientInit(const QString &rpcUrl)
 {
     qDebug() << "WalletModulePlugin::initWallet called";
-    Q_UNUSED(configJson);
 
-    const char* url = "https://ethereum-rpc.publicnode.com";
-    char* err = nullptr;
-    walletHandle = GoWSK_ethclient_NewClient((char*)url, &err);
-    if (walletHandle == 0) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin: Failed to create client:" << emsg;
+    if (ethClientHandles.contains(rpcUrl)) {
+        qWarning() << "WalletModulePlugin: Client already initialized:" << rpcUrl;
         return false;
     }
-    qDebug() << "WalletModulePlugin: Client created: handle=" << (qulonglong)walletHandle;
+
+    char* err = nullptr;
+    unsigned long long ethClientHandle = GoWSK_ethclient_NewClient((char*)rpcUrl.toUtf8().data(), &err);
+    if (ethClientHandle == 0) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin: Failed to create client:" << rpcUrl << emsg;
+        return false;
+    }
+    ethClientHandles[rpcUrl] = ethClientHandle;
     return true;
 }
 
-QString WalletModulePlugin::chainId(const QString &rpcUrl)
+bool WalletModulePlugin::ethClientClose(const QString &rpcUrl)
 {
-    qDebug() << "WalletModulePlugin::chainId" << rpcUrl;
-    Q_UNUSED(rpcUrl);
-    if (walletHandle == 0) {
-        if (!initWallet(QString())) {
-            return QString();
+    qDebug() << "WalletModulePlugin::ethClientClose" << rpcUrl;
+    if (!ethClientHandles.contains(rpcUrl)) {
+        qWarning() << "WalletModulePlugin: Client not initialized:" << rpcUrl;
+        return false;
+    }
+    unsigned long long ethClientHandle = ethClientHandles[rpcUrl];
+    GoWSK_ethclient_CloseClient(ethClientHandle);
+    ethClientHandles.remove(rpcUrl);
+    return true;
+}
+
+QStringList WalletModulePlugin::ethClientGetClients()
+{
+    qDebug() << "WalletModulePlugin::ethClientGetClients";
+    return ethClientHandles.keys();
+}
+
+unsigned long long WalletModulePlugin::getOrInitEthClient(const QString &rpcUrl)
+{
+    if (!ethClientHandles.contains(rpcUrl)) {
+        if (!ethClientInit(rpcUrl)) {
+            return 0;
         }
     }
+    return ethClientHandles[rpcUrl];
+}
+
+QString WalletModulePlugin::ethClientChainId(const QString &rpcUrl)
+{
+    qDebug() << "WalletModulePlugin::ethClientChainId" << rpcUrl;
+    unsigned long long ethClientHandle = getOrInitEthClient(rpcUrl);
+    if (ethClientHandle == 0) {
+        qWarning() << "WalletModulePlugin: Failed to get or initialize client:" << rpcUrl;
+        return QString();
+    }
     char* err = nullptr;
-    char* chain = GoWSK_ethclient_ChainID(walletHandle, &err);
+    char* chain = GoWSK_ethclient_ChainID(ethClientHandle, &err);
     if (chain == nullptr) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);
@@ -77,18 +108,17 @@ QString WalletModulePlugin::chainId(const QString &rpcUrl)
     return result;
 }
 
-QString WalletModulePlugin::getEthBalance(const QString &rpcUrl, const QString &address)
+QString WalletModulePlugin::ethClientGetBalance(const QString &rpcUrl, const QString &address)
 {
     qDebug() << "WalletModulePlugin::getEthBalance" << rpcUrl << address;
-    Q_UNUSED(rpcUrl);
-    if (walletHandle == 0) {
-        if (!initWallet(QString())) {
-            return QString();
-        }
+    unsigned long long ethClientHandle = getOrInitEthClient(rpcUrl);
+    if (ethClientHandle == 0) {
+        qWarning() << "WalletModulePlugin: Failed to get or initialize client:" << rpcUrl;
+        return QString();
     }
     QByteArray addrUtf8 = address.toUtf8();
     char* err = nullptr;
-    char* balance = GoWSK_ethclient_GetBalance(walletHandle, addrUtf8.data(), &err);
+    char* balance = GoWSK_ethclient_GetBalance(ethClientHandle, addrUtf8.data(), &err);
     if (balance == nullptr) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);
@@ -100,29 +130,19 @@ QString WalletModulePlugin::getEthBalance(const QString &rpcUrl, const QString &
     return result;
 }
 
-QString WalletModulePlugin::getErc20Balances(const QString &rpcUrl, const QString &address, const QStringList &tokenAddresses)
+QString WalletModulePlugin::ethClientRpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::getErc20Balances" << rpcUrl << address << tokenAddresses;
+    qDebug() << "WalletModulePlugin::ethClientRpcCall" << rpcUrl << method << paramsJSON;
     Q_UNUSED(rpcUrl);
-    Q_UNUSED(address);
-    Q_UNUSED(tokenAddresses);
-    // Not yet implemented in cshared; stub for future
-    return QString();
-}
-
-QString WalletModulePlugin::rpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON)
-{
-    qDebug() << "WalletModulePlugin::rpcCall" << rpcUrl << method << paramsJSON;
-    Q_UNUSED(rpcUrl);
-    if (walletHandle == 0) {
-        if (!initWallet(QString())) {
-            return QString();
-        }
+    unsigned long long ethClientHandle = getOrInitEthClient(rpcUrl);
+    if (ethClientHandle == 0) {
+        qWarning() << "WalletModulePlugin: Failed to get or initialize client:" << rpcUrl;
+        return QString();
     }
     QByteArray methodUtf8 = method.toUtf8();
     QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
     char* err = nullptr;
-    char* response = GoWSK_ethclient_RPCCall(walletHandle, methodUtf8.data(), paramsJsonUtf8.data(), &err);
+    char* response = GoWSK_ethclient_RPCCall(ethClientHandle, methodUtf8.data(), paramsJsonUtf8.data(), &err);
     if (response == nullptr) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);

--- a/wallet_module_plugin.cpp
+++ b/wallet_module_plugin.cpp
@@ -39,7 +39,7 @@ void WalletModulePlugin::simple_callback(int callerRet, const char* msg, size_t 
 
 bool WalletModulePlugin::ethClientInit(const QString &rpcUrl)
 {
-    qDebug() << "WalletModulePlugin::initWallet called";
+    qDebug() << "WalletModulePlugin::ethClientInit called";
 
     if (ethClientHandles.contains(rpcUrl)) {
         qWarning() << "WalletModulePlugin: Client already initialized:" << rpcUrl;
@@ -47,7 +47,8 @@ bool WalletModulePlugin::ethClientInit(const QString &rpcUrl)
     }
 
     char* err = nullptr;
-    unsigned long long ethClientHandle = GoWSK_ethclient_NewClient((char*)rpcUrl.toUtf8().data(), &err);
+    QByteArray rpcUrlUtf8 = rpcUrl.toUtf8();
+    unsigned long long ethClientHandle = GoWSK_ethclient_NewClient(const_cast<char*>(rpcUrlUtf8.data()), &err);
     if (ethClientHandle == 0) {
         QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
         if (err) GoWSK_FreeCString(err);
@@ -110,7 +111,7 @@ QString WalletModulePlugin::ethClientChainId(const QString &rpcUrl)
 
 QString WalletModulePlugin::ethClientGetBalance(const QString &rpcUrl, const QString &address)
 {
-    qDebug() << "WalletModulePlugin::getEthBalance" << rpcUrl << address;
+    qDebug() << "WalletModulePlugin::ethClientGetBalance" << rpcUrl << address;
     unsigned long long ethClientHandle = getOrInitEthClient(rpcUrl);
     if (ethClientHandle == 0) {
         qWarning() << "WalletModulePlugin: Failed to get or initialize client:" << rpcUrl;
@@ -133,7 +134,6 @@ QString WalletModulePlugin::ethClientGetBalance(const QString &rpcUrl, const QSt
 QString WalletModulePlugin::ethClientRpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON)
 {
     qDebug() << "WalletModulePlugin::ethClientRpcCall" << rpcUrl << method << paramsJSON;
-    Q_UNUSED(rpcUrl);
     unsigned long long ethClientHandle = getOrInitEthClient(rpcUrl);
     if (ethClientHandle == 0) {
         qWarning() << "WalletModulePlugin: Failed to get or initialize client:" << rpcUrl;
@@ -205,172 +205,116 @@ QString WalletModulePlugin::transactionGetHash(const QString &txJSON)
     return result;
 }
 
+namespace {
+    using TxGeneratorFunc = char* (*)(char*, char**);
+
+    QString callGoTxGenerator(const QString &paramsJSON,
+                                const char* logPrefix,
+                                TxGeneratorFunc func)
+    {
+        qDebug() << logPrefix << paramsJSON;
+        QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+        char* err = nullptr;
+        char* txJson = func(paramsJsonUtf8.data(), &err);
+        if (txJson == nullptr) {
+            QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+            if (err) GoWSK_FreeCString(err);
+            qWarning() << logPrefix << "error:" << emsg;
+            return QString();
+        }
+        QString result = QString::fromUtf8(txJson);
+        GoWSK_FreeCString(txJson);
+        return result;
+    }
+}
+
 QString WalletModulePlugin::txGeneratorTransferETH(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorTransferETH" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_TransferETH(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorTransferETH error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorTransferETH",
+        &GoWSK_txgenerator_TransferETH
+    );
 }
 
 QString WalletModulePlugin::txGeneratorTransferERC20(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorTransferERC20" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_TransferERC20(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorTransferERC20 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorTransferERC20",
+        &GoWSK_txgenerator_TransferERC20
+    );
 }
 
 QString WalletModulePlugin::txGeneratorApproveERC20(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorApproveERC20" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_ApproveERC20(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorApproveERC20 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorApproveERC20",
+        &GoWSK_txgenerator_ApproveERC20
+    );
 }
 
 QString WalletModulePlugin::txGeneratorTransferFromERC721(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorTransferFromERC721" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_TransferFromERC721(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorTransferFromERC721 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorTransferFromERC721",
+        &GoWSK_txgenerator_TransferFromERC721
+    );
 }
 
 QString WalletModulePlugin::txGeneratorSafeTransferFromERC721(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorSafeTransferFromERC721" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_SafeTransferFromERC721(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorSafeTransferFromERC721 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorSafeTransferFromERC721",
+        &GoWSK_txgenerator_SafeTransferFromERC721
+    );
 }
 
 QString WalletModulePlugin::txGeneratorApproveERC721(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorApproveERC721" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_ApproveERC721(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorApproveERC721 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorApproveERC721",
+        &GoWSK_txgenerator_ApproveERC721
+    );
 }
+
 
 QString WalletModulePlugin::txGeneratorSetApprovalForAllERC721(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC721" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_SetApprovalForAllERC721(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC721 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorSetApprovalForAllERC721",
+        &GoWSK_txgenerator_SetApprovalForAllERC721
+    );
 }
 
 QString WalletModulePlugin::txGeneratorTransferERC1155(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorTransferERC1155" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_TransferERC1155(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorTransferERC1155 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorTransferERC1155",
+        &GoWSK_txgenerator_TransferERC1155
+    );
 }
 
 QString WalletModulePlugin::txGeneratorBatchTransferERC1155(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorBatchTransferERC1155" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_BatchTransferERC1155(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorBatchTransferERC1155 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorBatchTransferERC1155",
+        &GoWSK_txgenerator_BatchTransferERC1155
+    );
 }
 
 QString WalletModulePlugin::txGeneratorSetApprovalForAllERC1155(const QString &paramsJSON)
 {
-    qDebug() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC1155" << paramsJSON;
-    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
-    char* err = nullptr;
-    char* txJson = GoWSK_txgenerator_SetApprovalForAllERC1155(paramsJsonUtf8.data(), &err);
-    if (txJson == nullptr) {
-        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
-        if (err) GoWSK_FreeCString(err);
-        qWarning() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC1155 error:" << emsg;
-        return QString();
-    }
-    QString result = QString::fromUtf8(txJson);
-    GoWSK_FreeCString(txJson);
-    return result;
+    return callGoTxGenerator(
+        paramsJSON,
+        "WalletModulePlugin::txGeneratorSetApprovalForAllERC1155",
+        &GoWSK_txgenerator_SetApprovalForAllERC1155
+    );
 }

--- a/wallet_module_plugin.cpp
+++ b/wallet_module_plugin.cpp
@@ -133,3 +133,224 @@ QString WalletModulePlugin::rpcCall(const QString &rpcUrl, const QString &method
     GoWSK_FreeCString(response);
     return result;
 }
+
+QString WalletModulePlugin::transactionJsonToRlp(const QString &txJSON)
+{
+    qDebug() << "WalletModulePlugin::transactionJsonToRlp" << txJSON;
+    QByteArray txJsonUtf8 = txJSON.toUtf8();
+    char* err = nullptr;
+    char* rlpHex = GoWSK_transaction_JSONToRLP(txJsonUtf8.data(), &err);
+    if (rlpHex == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModuleTransaction: JSONToRLP error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(rlpHex);
+    GoWSK_FreeCString(rlpHex);
+    return result;
+}
+
+QString WalletModulePlugin::transactionRlpToJson(const QString &rlpHex)
+{
+    qDebug() << "WalletModulePlugin::transactionRlpToJson" << rlpHex;
+    QByteArray rlpHexUtf8 = rlpHex.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_transaction_RLPToJSON(rlpHexUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModuleTransaction: RLPToJSON error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::transactionGetHash(const QString &txJSON)
+{
+    qDebug() << "WalletModulePlugin::transactionGetHash" << txJSON;
+    QByteArray txJsonUtf8 = txJSON.toUtf8();
+    char* err = nullptr;
+    char* hash = GoWSK_transaction_GetHash(txJsonUtf8.data(), &err);
+    if (hash == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::transactionGetHash error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(hash);
+    GoWSK_FreeCString(hash);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorTransferETH(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorTransferETH" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_TransferETH(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorTransferETH error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorTransferERC20(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorTransferERC20" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_TransferERC20(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorTransferERC20 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorApproveERC20(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorApproveERC20" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_ApproveERC20(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorApproveERC20 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorTransferFromERC721(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorTransferFromERC721" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_TransferFromERC721(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorTransferFromERC721 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorSafeTransferFromERC721(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorSafeTransferFromERC721" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_SafeTransferFromERC721(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorSafeTransferFromERC721 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorApproveERC721(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorApproveERC721" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_ApproveERC721(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorApproveERC721 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorSetApprovalForAllERC721(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC721" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_SetApprovalForAllERC721(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC721 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorTransferERC1155(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorTransferERC1155" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_TransferERC1155(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorTransferERC1155 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorBatchTransferERC1155(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorBatchTransferERC1155" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_BatchTransferERC1155(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorBatchTransferERC1155 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}
+
+QString WalletModulePlugin::txGeneratorSetApprovalForAllERC1155(const QString &paramsJSON)
+{
+    qDebug() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC1155" << paramsJSON;
+    QByteArray paramsJsonUtf8 = paramsJSON.toUtf8();
+    char* err = nullptr;
+    char* txJson = GoWSK_txgenerator_SetApprovalForAllERC1155(paramsJsonUtf8.data(), &err);
+    if (txJson == nullptr) {
+        QString emsg = err ? QString::fromUtf8(err) : QString("unknown error");
+        if (err) GoWSK_FreeCString(err);
+        qWarning() << "WalletModulePlugin::txGeneratorSetApprovalForAllERC1155 error:" << emsg;
+        return QString();
+    }
+    QString result = QString::fromUtf8(txJson);
+    GoWSK_FreeCString(txJson);
+    return result;
+}

--- a/wallet_module_plugin.h
+++ b/wallet_module_plugin.h
@@ -24,11 +24,12 @@ public:
     Q_INVOKABLE void initLogos(LogosAPI* logosAPIInstance);
 
     // EthClient operations
-    Q_INVOKABLE bool initWallet(const QString &configJson) override;
-    Q_INVOKABLE QString rpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON) override;
-    Q_INVOKABLE QString chainId(const QString &rpcUrl) override;
-    Q_INVOKABLE QString getEthBalance(const QString &rpcUrl, const QString &address) override;
-    Q_INVOKABLE QString getErc20Balances(const QString &rpcUrl, const QString &address, const QStringList &tokenAddresses) override;
+    Q_INVOKABLE bool ethClientInit(const QString &rpcUrl) override;
+    Q_INVOKABLE bool ethClientClose(const QString &rpcUrl) override;
+    Q_INVOKABLE QStringList ethClientGetClients() override;
+    Q_INVOKABLE QString ethClientRpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON) override;
+    Q_INVOKABLE QString ethClientChainId(const QString &rpcUrl) override;
+    Q_INVOKABLE QString ethClientGetBalance(const QString &rpcUrl, const QString &address) override;
 
     // TxGenerator operations
     Q_INVOKABLE QString txGeneratorTransferETH(const QString &paramsJSON) override;
@@ -51,9 +52,11 @@ signals:
     void eventResponse(const QString& eventName, const QVariantList& data);
 
 private:
-    unsigned long long walletHandle;
+    QMap<QString, unsigned long long> ethClientHandles;
 
     static void simple_callback(int callerRet, const char* msg, size_t len, void* userData);
+
+    unsigned long long getOrInitEthClient(const QString &rpcUrl);
 };
 
 

--- a/wallet_module_plugin.h
+++ b/wallet_module_plugin.h
@@ -19,15 +19,33 @@ public:
     WalletModulePlugin();
     ~WalletModulePlugin();
 
+    QString name() const override { return "wallet_module"; }
+    QString version() const override { return "1.0.0"; }
+    Q_INVOKABLE void initLogos(LogosAPI* logosAPIInstance);
+
+    // EthClient operations
     Q_INVOKABLE bool initWallet(const QString &configJson) override;
     Q_INVOKABLE QString rpcCall(const QString &rpcUrl, const QString &method, const QString &paramsJSON) override;
     Q_INVOKABLE QString chainId(const QString &rpcUrl) override;
     Q_INVOKABLE QString getEthBalance(const QString &rpcUrl, const QString &address) override;
     Q_INVOKABLE QString getErc20Balances(const QString &rpcUrl, const QString &address, const QStringList &tokenAddresses) override;
-    QString name() const override { return "wallet_module"; }
-    QString version() const override { return "1.0.0"; }
 
-    Q_INVOKABLE void initLogos(LogosAPI* logosAPIInstance);
+    // TxGenerator operations
+    Q_INVOKABLE QString txGeneratorTransferETH(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorTransferERC20(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorApproveERC20(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorTransferFromERC721(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorSafeTransferFromERC721(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorApproveERC721(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorSetApprovalForAllERC721(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorTransferERC1155(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorBatchTransferERC1155(const QString &paramsJSON) override;
+    Q_INVOKABLE QString txGeneratorSetApprovalForAllERC1155(const QString &paramsJSON) override;
+
+    // Transaction operations
+    Q_INVOKABLE QString transactionJsonToRlp(const QString &txJSON) override;
+    Q_INVOKABLE QString transactionRlpToJson(const QString &rlpHex) override;
+    Q_INVOKABLE QString transactionGetHash(const QString &txJSON) override;
 
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);


### PR DESCRIPTION
Bump go-wallet-sdk to get https://github.com/status-im/go-wallet-sdk/pull/34
Implement txGenerator and transactions API
Improved ethclient modules to handle multiple user-entered rpc URLs.